### PR TITLE
chore: Update withastro/actions from v1 -> v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v3
       - name: Install, build, and upload your site
-        uses: withastro/action@v1
+        uses: withastro/action@v4
         # with:
           # path: . # The root location of your Astro project inside the repository. (optional)
           # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)


### PR DESCRIPTION
The CI/CD pipeline was [failing](https://github.com/508-dev/englishvehiclestw/actions/runs/15734130128/job/44342205777#step:1:45) because withastro/actions v1 was using a deprecated library.